### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ otp_release:
   - 17.1
   - 17.4
 sudo: false # to use faster container based build environment
-script:
-  - mix test
 notifications:
   recipients:
     - martin@pspdfkit.com


### PR DESCRIPTION
Don't need to declare the `mix test` because that is the default.
